### PR TITLE
Introduce codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .env
 package-lock.json
 yarn.lock
+coverage

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "jest": "jest",
     "eslint": "eslint ./",
     "flow": "flow check",
+    "codecov": "codecov",
     "lint": "npm run eslint",
-    "test": "npm run jest && npm run flow",
+    "test": "npm run jest && npm run flow && npm run codecov",
     "changelog": "github-changes -o liuderchi -r gh-template-bot -b master -f ./CHANGELOG.md -t CHANGELOG --order-semver --use-commit-body"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "request-promise": "^4.2.2"
   },
   "devDependencies": {
+    "codecov": "^3.0.0",
     "eslint": "^4.11.0",
     "eslint-plugin-prettier": "^2.3.1",
     "flow-bin": "^0.59.0",
@@ -36,6 +38,21 @@
   },
   "engines": {
     "node": ">= 8.3.0"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}",
+      "!src/**/*.test.{js,jsx}",
+      "!src/**/*.flow.js"
+    ],
+    "coverageDirectory": "./coverage/",
+    "testPathIgnorePatterns": [
+      "<rootDir>/node_modules/",
+      "<rootDir>/coverage/",
+      "<rootDir>/flow-typed/"
+    ]
   },
   "standard": {
     "env": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,6 +165,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -703,6 +707,14 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+codecov@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.0.0.tgz#c273b8c4f12945723e8dc9d25803d89343e5f28e"
+  dependencies:
+    argv "0.0.2"
+    request "2.81.0"
+    urlgrey "0.4.4"
 
 color-convert@^1.9.0:
   version "1.9.1"
@@ -4518,6 +4530,10 @@ url-parse-lax@^1.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
   dependencies:
     prepend-http "^1.0.1"
+
+urlgrey@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 user-home@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
introduce codecov following https://github.com/codecov/example-node#jest

### Steps to introduce codecov

  - [x] [Report] for repo using jest, just add `jest` field config to tell jest generate coverage report after test
  - [x] [CC] get token from codecov.io
  - [x] [CC] install codecov github integration https://github.com/apps/codecov (need set permission)
  - [x] [Report] `yarn add -D codecov` and run `jest && codecov -t :codecov-token` 
      - generate then upload first coverage report to activate your repo in codecov
  - [x] [GH] commit then create PR, codecov bot will show report for you
  - [x] [GH] tweak `jest` config for correct coverage [(_Example)](https://github.com/evenchange4/gh-polls-bot/blob/master/package.json#L59-L71)